### PR TITLE
adding support for getting the information with ip and not route

### DIFF
--- a/gateway_linux.go
+++ b/gateway_linux.go
@@ -7,7 +7,36 @@ import (
 	"os/exec"
 )
 
-func DiscoverGateway() (ip net.IP, err error) {
+func discoverGateWayUsingIp() (ip net.IP, err error) {
+	routeCmd := exec.Command("ip", "route", "show")
+	stdOut, err := routeCmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	if err = routeCmd.Start(); err != nil {
+		return
+	}
+	output, err := ioutil.ReadAll(stdOut)
+	if err != nil {
+		return
+	}
+
+	// Linux 'ip route show' format looks like this:
+	// default via 192.168.178.1 dev wlp3s0  metric 303
+	// 192.168.178.0/24 dev wlp3s0  proto kernel  scope link  src 192.168.178.76  metric 303
+	outputLines := bytes.Split(output, []byte("\n"))
+	for _, line := range outputLines {
+		if bytes.Contains(line, []byte("default")) {
+			ipFields := bytes.Fields(line)
+			ip = net.ParseIP(string(ipFields[2]))
+			break
+		}
+	}
+	err = routeCmd.Wait()
+	return
+}
+
+func discoverGateWayUsingRoute() (ip net.IP, err error) {
 	routeCmd := exec.Command("route", "-n")
 	stdOut, err := routeCmd.StdoutPipe()
 	if err != nil {
@@ -34,5 +63,13 @@ func DiscoverGateway() (ip net.IP, err error) {
 		}
 	}
 	err = routeCmd.Wait()
+	return
+}
+
+func DiscoverGateway() (ip net.IP, err error) {
+	ip, err = discoverGateWayUsingRoute()
+	if err != nil {
+		ip, err = discoverGateWayUsingIp()
+	}
 	return
 }


### PR DESCRIPTION
Here is a patch for getting the gateway using the command 'ip route show' on linux, when 'route -n' fails.

The reason for this patch is that on my system, route is not installed by default, but 'ip' is. 'ip' seems to be the new standard tool for managing the network, so I think it would nice to include it.