### PR TITLE
Use full path to /sbin/route

### DIFF
--- a/gateway_darwin.go
+++ b/gateway_darwin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func DiscoverGateway() (ip net.IP, err error) {
-	routeCmd := exec.Command("route", "-n", "get", "0.0.0.0")
+	routeCmd := exec.Command("/sbin/route", "-n", "get", "0.0.0.0")
 	stdOut, err := routeCmd.StdoutPipe()
 	if err != nil {
 		return


### PR DESCRIPTION
This fixes gateway resolution when the PATH is not set to include `/sbin`