### PR TITLE
Make Windows route print parsing more robust (fixes #5)

### DIFF
--- a/gateway_common.go
+++ b/gateway_common.go
@@ -1,0 +1,38 @@
+package gateway
+
+import (
+	"bytes"
+	"errors"
+	"net"
+)
+
+var errNoGateway = errors.New("no gateway found")
+
+func parseRoutePrint(output []byte) (net.IP, error) {
+	// Windows route output format is always like this:
+	// ===========================================================================
+	// Active Routes:
+	// Network Destination        Netmask          Gateway       Interface  Metric
+	//           0.0.0.0          0.0.0.0      192.168.1.1    192.168.1.100     20
+	// ===========================================================================
+	// I'm trying to pick the active route,
+	// then jump 2 lines and pick the third IP
+	// Not using regex because output is quite standard from Windows XP to 8 (NEEDS TESTING)
+	outputLines := bytes.Split(output, []byte("\n"))
+	for idx, line := range outputLines {
+		if bytes.Contains(line, []byte("Active Routes:")) {
+			if len(outputLines) <= idx+2 {
+				return nil, errNoGateway
+			}
+
+			ipFields := bytes.Fields(outputLines[idx+2])
+			if len(ipFields) < 3 {
+				return nil, errNoGateway
+			}
+
+			ip := net.ParseIP(string(ipFields[2]))
+			return ip, nil
+		}
+	}
+	return nil, errNoGateway
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -8,3 +8,57 @@ func TestGateway(t *testing.T) {
 		t.Errorf("DiscoverGateway() = %v,%v", ip, err)
 	}
 }
+
+func TestParseRoutePrint(t *testing.T) {
+	correctData := []byte(`
+IPv4 Route Table
+===========================================================================
+Active Routes:
+Network Destination        Netmask          Gateway       Interface  Metric
+          0.0.0.0          0.0.0.0       10.88.88.2     10.88.88.149     10
+===========================================================================
+Persistent Routes:
+`)
+	randomData := []byte(`
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+`)
+	noRoute := []byte(`
+IPv4 Route Table
+===========================================================================
+Active Routes:
+`)
+	badRoute := []byte(`
+IPv4 Route Table
+===========================================================================
+Active Routes:
+===========================================================================
+Persistent Routes:
+`)
+
+	testcases := []struct {
+		output  []byte
+		ok      bool
+		gateway string
+	}{
+		{correctData, true, "10.88.88.2"},
+		{randomData, false, ""},
+		{noRoute, false, ""},
+		{badRoute, false, ""},
+	}
+
+	for i, tc := range testcases {
+		net, err := parseRoutePrint(tc.output)
+		if tc.ok {
+			if err != nil {
+				t.Errorf("Unexpected error in test #%d: %v", i, err)
+			}
+			if net.String() != tc.gateway {
+				t.Errorf("Unexpected gateway address %v != %s", net, tc.gateway)
+			}
+		} else if err == nil {
+			t.Errorf("Unexpected nil error in test #%d", i)
+		}
+	}
+}

--- a/gateway_windows.go
+++ b/gateway_windows.go
@@ -1,43 +1,16 @@
 package gateway
 
 import (
-	"bytes"
-	"io/ioutil"
 	"net"
 	"os/exec"
 )
 
 func DiscoverGateway() (ip net.IP, err error) {
 	routeCmd := exec.Command("route", "print", "0.0.0.0")
-	stdOut, err := routeCmd.StdoutPipe()
+	output, err := routeCmd.CombinedOutput()
 	if err != nil {
-		return
-	}
-	if err = routeCmd.Start(); err != nil {
-		return
-	}
-	output, err := ioutil.ReadAll(stdOut)
-	if err != nil {
-		return
+		return nil, err
 	}
 
-	// Windows route output format is always like this:
-	// ===========================================================================
-	// Active Routes:
-	// Network Destination        Netmask          Gateway       Interface  Metric
-	//           0.0.0.0          0.0.0.0      192.168.1.1    192.168.1.100     20
-	// ===========================================================================
-	// I'm trying to pick the active route,
-	// then jump 2 lines and pick the third IP
-	// Not using regex because output is quite standard from Windows XP to 8 (NEEDS TESTING)
-	outputLines := bytes.Split(output, []byte("\n"))
-	for idx, line := range outputLines {
-		if bytes.Contains(line, []byte("Active Routes:")) {
-			ipFields := bytes.Fields(outputLines[idx+2])
-			ip = net.ParseIP(string(ipFields[2]))
-			break
-		}
-	}
-	err = routeCmd.Wait()
-	return
+	return parseRoutePrint(output)
 }


### PR DESCRIPTION
This breaks out the parsing into a separate function for testing, and subjects it to some forms of invalid data. Also simplifies the "read all output" from route print step.