### PR TITLE
Buffered IO and strings

### DIFF
--- a/gateway_linux.go
+++ b/gateway_linux.go
@@ -1,10 +1,10 @@
 package gateway
 
 import (
-	"bytes"
-	"io/ioutil"
+	"bufio"
 	"net"
 	"os/exec"
+	"strings"
 )
 
 func discoverGatewayUsingIp() (ip net.IP, err error) {
@@ -16,22 +16,18 @@ func discoverGatewayUsingIp() (ip net.IP, err error) {
 	if err = routeCmd.Start(); err != nil {
 		return
 	}
-	output, err := ioutil.ReadAll(stdOut)
-	if err != nil {
-		return
-	}
 
 	// Linux 'ip route show' format looks like this:
 	// default via 192.168.178.1 dev wlp3s0  metric 303
 	// 192.168.178.0/24 dev wlp3s0  proto kernel  scope link  src 192.168.178.76  metric 303
-	outputLines := bytes.Split(output, []byte("\n"))
-	for _, line := range outputLines {
-		if bytes.Contains(line, []byte("default")) {
-			ipFields := bytes.Fields(line)
-			ip = net.ParseIP(string(ipFields[2]))
+	for cmdScanner := bufio.NewScanner(stdOut); ; cmdScanner.Scan() {
+		if line := cmdScanner.Text(); strings.Contains(line, "default") {
+			ipFields := strings.Fields(line)
+			ip = net.ParseIP(ipFields[2])
 			break
 		}
 	}
+
 	err = routeCmd.Wait()
 	return
 }
@@ -45,23 +41,19 @@ func discoverGatewayUsingRoute() (ip net.IP, err error) {
 	if err = routeCmd.Start(); err != nil {
 		return
 	}
-	output, err := ioutil.ReadAll(stdOut)
-	if err != nil {
-		return
-	}
 
 	// Linux route out format is always like this:
 	// Kernel IP routing table
 	// Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 	// 0.0.0.0         192.168.1.1     0.0.0.0         UG    0      0        0 eth0
-	outputLines := bytes.Split(output, []byte("\n"))
-	for _, line := range outputLines {
-		if bytes.Contains(line, []byte("0.0.0.0")) {
-			ipFields := bytes.Fields(line)
-			ip = net.ParseIP(string(ipFields[1]))
+	for cmdScanner := bufio.NewScanner(stdOut); ; cmdScanner.Scan() {
+		if line := cmdScanner.Text(); strings.Contains(line, "0.0.0.0") {
+			ipFields := strings.Fields(line)
+			ip = net.ParseIP(ipFields[1])
 			break
 		}
 	}
+
 	err = routeCmd.Wait()
 	return
 }

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -6,5 +6,8 @@ func TestGateway(t *testing.T) {
 	ip, err := DiscoverGateway()
 	if err != nil {
 		t.Errorf("DiscoverGateway() = %v,%v", ip, err)
+	} else {
+		t.Logf("ip %v\n", ip)
 	}
+
 }


### PR DESCRIPTION
This is a PR that includes these changes that I've made in a personal fork: 
 - using `bufio.Scanner` instead of the `io.All`
 - using `strings` instead of `bytes` as possible
 - adding a log statement of found gateway ip (when using `go test -v`)

