### PR TITLE
Support FreeBSD and Solaris by "netstat -rn"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 A very simple library for discovering the IP address of the local LAN gateway.
 
-Provides implementations for Linux, OS X (Darwin) and Windows.
+Provides implementations for Linux, OS X (Darwin), Windows, FreeBSD and Solaris.
 
 Pull requests for other OSs happily considered!

--- a/gateway_common.go
+++ b/gateway_common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"net"
+	"strings"
 )
 
 var errNoGateway = errors.New("no gateway found")
@@ -34,5 +35,37 @@ func parseRoutePrint(output []byte) (net.IP, error) {
 			return ip, nil
 		}
 	}
+	return nil, errNoGateway
+}
+
+func parseNetstat(output []byte) (net.IP, error) {
+	// netstat -rn produces the following on FreeBSD:
+	// Routing tables
+	//
+	// Internet:
+	// Destination        Gateway            Flags      Netif Expire
+	// default            10.88.88.2         UGS         em0
+	// 10.88.88.0/24      link#1             U           em0
+	// 10.88.88.148       link#1             UHS         lo0
+	// 127.0.0.1          link#2             UH          lo0
+	//
+	// Internet6:
+	// Destination                       Gateway                       Flags      Netif Expire
+	// ::/96                             ::1                           UGRS        lo0
+	// ::1                               link#2                        UH          lo0
+	// ::ffff:0.0.0.0/96                 ::1                           UGRS        lo0
+	// fe80::/10                         ::1                           UGRS        lo0
+	// ...
+	outputLines := strings.Split(string(output), "\n")
+	for _, line := range outputLines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "default" {
+			ip := net.ParseIP(fields[1])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
 	return nil, errNoGateway
 }

--- a/gateway_freebsd.go
+++ b/gateway_freebsd.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	routeCmd := exec.Command("netstat", "-rn")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNetstat(output)
+}

--- a/gateway_solaris.go
+++ b/gateway_solaris.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"net"
+	"os/exec"
+)
+
+func DiscoverGateway() (ip net.IP, err error) {
+	routeCmd := exec.Command("netstat", "-rn")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNetstat(output)
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -65,3 +65,84 @@ Persistent Routes:
 		}
 	}
 }
+
+func TestParseNetstat(t *testing.T) {
+	correctDataFreeBSD := []byte(`
+Routing tables
+
+Internet:
+Destination        Gateway            Flags      Netif Expire
+default            10.88.88.2         UGS         em0
+10.88.88.0/24      link#1             U           em0
+10.88.88.148       link#1             UHS         lo0
+127.0.0.1          link#2             UH          lo0
+
+Internet6:
+Destination                       Gateway                       Flags      Netif Expire
+::/96                             ::1                           UGRS        lo0
+::1                               link#2                        UH          lo0
+::ffff:0.0.0.0/96                 ::1                           UGRS        lo0
+fe80::/10                         ::1                           UGRS        lo0
+`)
+	correctDataSolaris := []byte(`
+Routing Table: IPv4
+  Destination           Gateway           Flags  Ref     Use     Interface
+-------------------- -------------------- ----- ----- ---------- ---------
+default              172.16.32.1          UG        2      76419 net0
+127.0.0.1            127.0.0.1            UH        2         36 lo0
+172.16.32.0          172.16.32.17         U         4       8100 net0
+
+Routing Table: IPv6
+  Destination/Mask            Gateway                   Flags Ref   Use    If
+--------------------------- --------------------------- ----- --- ------- -----
+::1                         ::1                         UH      3   75382 lo0
+2001:470:deeb:32::/64       2001:470:deeb:32::17        U       3    2744 net0
+fe80::/10                   fe80::6082:52ff:fedc:7df0   U       3    8430 net0
+`)
+	randomData := []byte(`
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+`)
+	noRoute := []byte(`
+Internet:
+Destination        Gateway            Flags      Netif Expire
+10.88.88.0/24      link#1             U           em0
+10.88.88.148       link#1             UHS         lo0
+127.0.0.1          link#2             UH          lo0
+`)
+	badRoute := []byte(`
+Internet:
+Destination        Gateway            Flags      Netif Expire
+default            foo                UGS         em0
+10.88.88.0/24      link#1             U           em0
+10.88.88.148       link#1             UHS         lo0
+127.0.0.1          link#2             UH          lo0
+`)
+
+	testcases := []struct {
+		output  []byte
+		ok      bool
+		gateway string
+	}{
+		{correctDataFreeBSD, true, "10.88.88.2"},
+		{correctDataSolaris, true, "172.16.32.1"},
+		{randomData, false, ""},
+		{noRoute, false, ""},
+		{badRoute, false, ""},
+	}
+
+	for i, tc := range testcases {
+		net, err := parseNetstat(tc.output)
+		if tc.ok {
+			if err != nil {
+				t.Errorf("Unexpected error in test #%d: %v", i, err)
+			}
+			if net.String() != tc.gateway {
+				t.Errorf("Unexpected gateway address %v != %s", net, tc.gateway)
+			}
+		} else if err == nil {
+			t.Errorf("Unexpected nil error in test #%d", i)
+		}
+	}
+}

--- a/gateway_unimplemented.go
+++ b/gateway_unimplemented.go
@@ -1,4 +1,4 @@
-// +build !darwin,!linux,!windows
+// +build !darwin,!linux,!windows,!solaris,!freebsd
 
 package gateway
 


### PR DESCRIPTION
Both output similar data and can be parsed the same way. The _freebsd and _solaris files could of course be combined into something with an explicit build tag instead if you prefer, as the code is the same in both.