### PR TITLE
Refactor out parsing code, simplify execution, improve testing

### DIFF
--- a/gateway_darwin.go
+++ b/gateway_darwin.go
@@ -1,36 +1,16 @@
 package gateway
 
 import (
-	"bufio"
 	"net"
 	"os/exec"
-	"strings"
 )
 
-func DiscoverGateway() (ip net.IP, err error) {
+func DiscoverGateway() (net.IP, error) {
 	routeCmd := exec.Command("/sbin/route", "-n", "get", "0.0.0.0")
-	stdOut, err := routeCmd.StdoutPipe()
+	output, err := routeCmd.CombinedOutput()
 	if err != nil {
-		return
-	}
-	if err = routeCmd.Start(); err != nil {
-		return
+		return nil, err
 	}
 
-	// Darwin route out format is always like this:
-	//    route to: default
-	// destination: default
-	//        mask: default
-	//     gateway: 192.168.1.1
-	for cmdScanner := bufio.NewScanner(stdOut); ; cmdScanner.Scan() {
-		if line := cmdScanner.Text(); strings.Contains(line, "gateway:") {
-			gatewayFields := strings.Fields(line)
-			ip = net.ParseIP(gatewayFields[1])
-			break
-		}
-	}
-
-	stdOut.Close()
-	err = routeCmd.Wait()
-	return
+	return parseDarwinRouteGet(output)
 }

--- a/gateway_freebsd.go
+++ b/gateway_freebsd.go
@@ -12,5 +12,5 @@ func DiscoverGateway() (ip net.IP, err error) {
 		return nil, err
 	}
 
-	return parseNetstat(output)
+	return parseBSDSolarisNetstat(output)
 }

--- a/gateway_linux.go
+++ b/gateway_linux.go
@@ -1,63 +1,9 @@
 package gateway
 
 import (
-	"bufio"
 	"net"
 	"os/exec"
-	"strings"
 )
-
-func discoverGatewayUsingIp() (ip net.IP, err error) {
-	routeCmd := exec.Command("/usr/bin/ip", "route", "show")
-	stdOut, err := routeCmd.StdoutPipe()
-	if err != nil {
-		return
-	}
-	if err = routeCmd.Start(); err != nil {
-		return
-	}
-
-	// Linux '/usr/bin/ip route show' format looks like this:
-	// default via 192.168.178.1 dev wlp3s0  metric 303
-	// 192.168.178.0/24 dev wlp3s0  proto kernel  scope link  src 192.168.178.76  metric 303
-	for cmdScanner := bufio.NewScanner(stdOut); ; cmdScanner.Scan() {
-		if line := cmdScanner.Text(); strings.Contains(line, "default") {
-			ipFields := strings.Fields(line)
-			ip = net.ParseIP(ipFields[2])
-			break
-		}
-	}
-
-	stdOut.Close()
-	err = routeCmd.Wait()
-	return
-}
-
-func discoverGatewayUsingRoute() (ip net.IP, err error) {
-	routeCmd := exec.Command("route", "-n")
-	stdOut, err := routeCmd.StdoutPipe()
-	if err != nil {
-		return
-	}
-	if err = routeCmd.Start(); err != nil {
-		return
-	}
-
-	// Linux route out format is always like this:
-	// Kernel IP routing table
-	// Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
-	// 0.0.0.0         192.168.1.1     0.0.0.0         UG    0      0        0 eth0
-	for cmdScanner := bufio.NewScanner(stdOut); ; cmdScanner.Scan() {
-		if line := cmdScanner.Text(); strings.Contains(line, "0.0.0.0") {
-			ipFields := strings.Fields(line)
-			ip = net.ParseIP(ipFields[1])
-			break
-		}
-	}
-
-	err = routeCmd.Wait()
-	return
-}
 
 func DiscoverGateway() (ip net.IP, err error) {
 	ip, err = discoverGatewayUsingRoute()
@@ -65,4 +11,24 @@ func DiscoverGateway() (ip net.IP, err error) {
 		ip, err = discoverGatewayUsingIp()
 	}
 	return
+}
+
+func discoverGatewayUsingIp() (net.IP, error) {
+	routeCmd := exec.Command("/usr/bin/ip", "route", "show")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxIPRoute(output)
+}
+
+func discoverGatewayUsingRoute() (net.IP, error) {
+	routeCmd := exec.Command("route", "-n")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxRoute(output)
 }

--- a/gateway_solaris.go
+++ b/gateway_solaris.go
@@ -12,5 +12,5 @@ func DiscoverGateway() (ip net.IP, err error) {
 		return nil, err
 	}
 
-	return parseNetstat(output)
+	return parseBSDSolarisNetstat(output)
 }

--- a/gateway_windows.go
+++ b/gateway_windows.go
@@ -12,5 +12,5 @@ func DiscoverGateway() (ip net.IP, err error) {
 		return nil, err
 	}
 
-	return parseRoutePrint(output)
+	return parseWindowsRoutePrint(output)
 }


### PR DESCRIPTION
This moves all of the parsing code to common and adds some tests to them. The diff is quite ugly but the end result is that the platform specific functions are essentially all just wrappers around CombinedOutput + calling the parser, and the parsers all live in the common file for easier testing.

The test code isn't particularly beautiful due to the large static strings being declared, but that's what it is. The naming of stuff can surely be nitpicked, I've gone with `parse$platform$method` mostly to keep it somewhat unambiguous... 