### PR TITLE
support "ip route get" as fallback on linux systems

### DIFF
--- a/gateway_common.go
+++ b/gateway_common.go
@@ -39,7 +39,7 @@ func parseWindowsRoutePrint(output []byte) (net.IP, error) {
 	return nil, errNoGateway
 }
 
-func parseLinuxIPRoute(output []byte) (net.IP, error) {
+func parseLinuxIPRouteShow(output []byte) (net.IP, error) {
 	// Linux '/usr/bin/ip route show' format looks like this:
 	// default via 192.168.178.1 dev wlp3s0  metric 303
 	// 192.168.178.0/24 dev wlp3s0  proto kernel  scope link  src 192.168.178.76  metric 303
@@ -47,6 +47,23 @@ func parseLinuxIPRoute(output []byte) (net.IP, error) {
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) >= 3 && fields[0] == "default" {
+			ip := net.ParseIP(fields[2])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+
+	return nil, errNoGateway
+}
+
+func parseLinuxIPRouteGet(output []byte) (net.IP, error) {
+	// Linux '/usr/bin/ip route get 8.8.8.8' format looks like this:
+	// 8.8.8.8 via 10.0.1.1 dev eth0  src 10.0.1.36  uid 2000
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "via" {
 			ip := net.ParseIP(fields[2])
 			if ip != nil {
 				return ip, nil

--- a/gateway_linux.go
+++ b/gateway_linux.go
@@ -8,19 +8,32 @@ import (
 func DiscoverGateway() (ip net.IP, err error) {
 	ip, err = discoverGatewayUsingRoute()
 	if err != nil {
-		ip, err = discoverGatewayUsingIp()
+		ip, err = discoverGatewayUsingIpRouteShow()
+	}
+	if err != nil {
+		ip, err = discoverGatewayUsingIpRouteGet()
 	}
 	return
 }
 
-func discoverGatewayUsingIp() (net.IP, error) {
+func discoverGatewayUsingIpRouteShow() (net.IP, error) {
 	routeCmd := exec.Command("ip", "route", "show")
 	output, err := routeCmd.CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
 
-	return parseLinuxIPRoute(output)
+	return parseLinuxIPRouteShow(output)
+}
+
+func discoverGatewayUsingIpRouteGet() (net.IP, error) {
+	routeCmd := exec.Command("ip", "route", "get", "8.8.8.8")
+	output, err := routeCmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseLinuxIPRouteGet(output)
 }
 
 func discoverGatewayUsingRoute() (net.IP, error) {


### PR DESCRIPTION
this fixes gateway lookups on android, where neither `netstat -rn`
nor `ip route show` display the gateway.

```
$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
10.0.1.0        0.0.0.0         255.255.255.0   U     0      0        0 eth0

$ ip route show
10.0.1.0/24 dev eth0  proto kernel  scope link  src 10.0.1.36

$ ip route get 8.8.8.8
8.8.8.8 via 10.0.1.1 dev eth0  src 10.0.1.36  uid 2000
    cache
```