### PR TITLE
Support localized output of Windows commands

### DIFF
--- a/gateway_common.go
+++ b/gateway_common.go
@@ -11,16 +11,26 @@ var errNoGateway = errors.New("no gateway found")
 func parseWindowsRoutePrint(output []byte) (net.IP, error) {
 	// Windows route output format is always like this:
 	// ===========================================================================
+	// Interface List
+	// 8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+	// 1 ........................... Software Loopback Interface 1
+	// ===========================================================================
+	// IPv4 Route Table
+	// ===========================================================================
 	// Active Routes:
 	// Network Destination        Netmask          Gateway       Interface  Metric
 	//           0.0.0.0          0.0.0.0      192.168.1.1    192.168.1.100     20
 	// ===========================================================================
+	//
+	// Windows commands are localized, so we can't just look for "Active Routes:" string
 	// I'm trying to pick the active route,
 	// then jump 2 lines and pick the third IP
 	// Not using regex because output is quite standard from Windows XP to 8 (NEEDS TESTING)
 	lines := strings.Split(string(output), "\n")
+	sep := 0
 	for idx, line := range lines {
-		if strings.HasPrefix(line, "Active Routes:") {
+		if sep == 3 {
+			// We just entered the 2nd section containing "Active Routes:"
 			if len(lines) <= idx+2 {
 				return nil, errNoGateway
 			}
@@ -34,6 +44,10 @@ func parseWindowsRoutePrint(output []byte) (net.IP, error) {
 			if ip != nil {
 				return ip, nil
 			}
+		}
+		if strings.HasPrefix(line, "=======") {
+			sep++
+			continue
 		}
 	}
 	return nil, errNoGateway

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -13,6 +13,11 @@ type testcase struct {
 
 func TestParseWindowsRoutePrint(t *testing.T) {
 	correctData := []byte(`
+===========================================================================
+Interface List
+  8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+  1 ........................... Software Loopback Interface 1
+===========================================================================
 IPv4 Route Table
 ===========================================================================
 Active Routes:
@@ -21,17 +26,42 @@ Network Destination        Netmask          Gateway       Interface  Metric
 ===========================================================================
 Persistent Routes:
 `)
+	localizedData := []byte(
+`===========================================================================
+Liste d'Interfaces
+ 17...00 28 f8 39 61 6b ......Microsoft Wi-Fi Direct Virtual Adapter
+  1...........................Software Loopback Interface 1
+===========================================================================
+IPv4 Table de routage
+===========================================================================
+Itinéraires actifs :
+Destination réseau    Masque réseau  Adr. passerelle   Adr. interface Métrique
+          0.0.0.0          0.0.0.0      10.88.88.2     10.88.88.149     10
+===========================================================================
+Itinéraires persistants :
+  Aucun
+`)
 	randomData := []byte(`
 Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 sed do eiusmod tempor incididunt ut labore et dolore magna
 aliqua. Ut enim ad minim veniam, quis nostrud exercitation
 `)
 	noRoute := []byte(`
+===========================================================================
+Interface List
+  8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+  1 ........................... Software Loopback Interface 1
+===========================================================================
 IPv4 Route Table
 ===========================================================================
 Active Routes:
 `)
 	badRoute1 := []byte(`
+===========================================================================
+Interface List
+  8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+  1 ........................... Software Loopback Interface 1
+===========================================================================
 IPv4 Route Table
 ===========================================================================
 Active Routes:
@@ -39,6 +69,11 @@ Active Routes:
 Persistent Routes:
 `)
 	badRoute2 := []byte(`
+===========================================================================
+Interface List
+  8 ...00 12 3f a7 17 ba ...... Intel(R) PRO/100 VE Network Connection
+  1 ........................... Software Loopback Interface 1
+===========================================================================
 IPv4 Route Table
 ===========================================================================
 Active Routes:
@@ -50,6 +85,7 @@ Persistent Routes:
 
 	testcases := []testcase{
 		{correctData, true, "10.88.88.2"},
+		{localizedData, true, "10.88.88.2"},
 		{randomData, false, ""},
 		{noRoute, false, ""},
 		{badRoute1, false, ""},


### PR DESCRIPTION
This changes the output parsing logic from "_search for 'Active Routes:'_" to "_search for 2nd section_".

Includes a test case for French localized output 