### PR TITLE
Fallback to netstat on darwin systems if route fails

### DIFF
--- a/gateway_parsers.go
+++ b/gateway_parsers.go
@@ -244,6 +244,27 @@ func parseDarwinRouteGet(output []byte) (net.IP, error) {
 	return nil, errNoGateway
 }
 
+func parseDarwinNetstat(output []byte) (net.IP, error) {
+	// Darwin netstat -nr out format is always like this:
+	// Routing tables
+
+	// Internet:
+	// Destination        Gateway            Flags           Netif Expire
+	// default            link#17            UCSg            utun3
+	// default            192.168.1.1      	 UGScIg            en0
+	outputLines := strings.Split(string(output), "\n")
+	for _, line := range outputLines {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "default" {
+			ip := net.ParseIP(fields[1])
+			if ip != nil {
+				return ip, nil
+			}
+		}
+	}
+	return nil, errNoGateway
+}
+
 func parseBSDSolarisNetstat(output []byte) (net.IP, error) {
 	// netstat -rn produces the following on FreeBSD:
 	// Routing tables

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -245,6 +245,47 @@ destination: default
 	test(t, testcases, parseDarwinRouteGet)
 }
 
+func TestParseDarwinNetstat(t *testing.T) {
+	correctDataDarwin := []byte(`
+Internet:
+Destination        Gateway            Flags           Netif Expire
+default            link#17            UCSg            utun3
+default            192.168.1.254      UGScIg            en0
+`)
+	randomData := []byte(`
+test
+Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+`)
+
+	noRoute := []byte(`
+Internet:
+Destination        Gateway            Flags      Netif Expire
+10.88.88.0/24      link#1             U           em0
+10.88.88.148       link#1             UHS         lo0
+127.0.0.1          link#2             UH          lo0
+`)
+
+	badRoute := []byte(`
+Internet:
+Destination        Gateway            Flags      Netif Expire
+default            foo                UGS         em0
+10.88.88.0/24      link#1             U           em0
+10.88.88.148       link#1             UHS         lo0
+127.0.0.1          link#2             UH          lo0
+`)
+
+	testcases := []testcase{
+		{correctDataDarwin, true, "192.168.1.254"},
+		{randomData, false, ""},
+		{noRoute, false, ""},
+		{badRoute, false, ""},
+	}
+
+	test(t, testcases, parseDarwinNetstat)
+}
+
 func test(t *testing.T, testcases []testcase, fn func([]byte) (net.IP, error)) {
 	for i, tc := range testcases {
 		net, err := fn(tc.output)


### PR DESCRIPTION
# What this does
- Addresses https://github.com/jackpal/gateway/issues/34.
- If parsing the `/sbin/route` output fails to produce a non-nil ip due to it not existing in the output, fallback to using netstat.

# Tests

`go test -v --run TestParseDarwinNetstat`