### PR TITLE
Fix panic when interface not set in Solaris `netstat -rn` output

### DIFF
--- a/gateway_parsers.go
+++ b/gateway_parsers.go
@@ -390,8 +390,12 @@ func parseNetstatToRouteStruct(output []byte) (unixRouteStruct, error) {
 		}
 
 		if fields[nsFields[ns_destination]] == "default" && flagsContain(fields[nsFields[ns_flags]], "U", "G") {
+			iface := ""
+			if ifaceIdx := nsFields[ns_netif]; ifaceIdx < len(fields) {
+				iface = fields[nsFields[ns_netif]]
+			}
 			return unixRouteStruct{
-				Iface:   fields[nsFields[ns_netif]],
+				Iface:   iface,
 				Gateway: fields[nsFields[ns_gateway]],
 			}, nil
 		}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -121,6 +121,7 @@ func TestParseUnix(t *testing.T) {
 		{freeBSD, true, "10.88.88.2", nil},
 		{netBSD, true, "172.31.16.1", nil},
 		{solaris, true, "172.16.32.1", nil},
+		{solarisNoInterface, true, "172.16.32.1", nil},
 		{randomData, false, "", &ErrCantParse{}},
 		{darwinNoRoute, false, "", &ErrNoGateway{}},
 		{darwinBadRoute, false, "", &ErrCantParse{}},
@@ -143,6 +144,7 @@ func TestParseUnix(t *testing.T) {
 		{freeBSD, "ena0", true, "10.88.88.2", nil},
 		{netBSD, "ena0", true, "172.31.16.1", nil},
 		{solaris, "net0", true, "172.16.32.1", nil},
+		{solarisNoInterface, "", true, "172.16.32.1", nil},
 		{randomData, "", false, "", &ErrCantParse{}},
 		{darwinNoRoute, "", false, "", &ErrNoGateway{}},
 		{darwinBadRoute, "en0", true, "192.168.1.254", &ErrCantParse{}},
@@ -262,6 +264,7 @@ func TestDiscoverFields(t *testing.T) {
 		{"FreeBSD", routeTables[freeBSD]},
 		{"NetBSD", routeTables[netBSD]},
 		{"Solaris", routeTables[solaris]},
+		{"Illumos", routeTables[solarisNoInterface]},
 	}
 
 	for _, testcase := range testcases {

--- a/route-tables/solarisNoInterface.txt
+++ b/route-tables/solarisNoInterface.txt
@@ -1,0 +1,13 @@
+Routing Table: IPv4
+  Destination            Gateway          Flags  Ref     Use     Interface
+-------------------- -------------------- ----- ----- ---------- ---------
+default              172.16.32.1          UG       49  681748414
+127.0.0.1            127.0.0.1            UH        2      52832 lo0
+172.16.32.0          172.16.32.17         U         5    1450483 net0
+
+Routing Table: IPv6
+  Destination/Mask            Gateway                   Flags Ref   Use    If
+--------------------------- --------------------------- ----- --- ------- -----
+::1                         ::1                         UH      2     966 lo0
+fe80::/10                   fe80::aabb:ccdd:1234:2      U       5   77620 net0
+default                     fe80::aabb:ccdd:1234:1      UG      3 4092447

--- a/test_route_tables.go
+++ b/test_route_tables.go
@@ -17,6 +17,7 @@ const (
 	solarisBadRoute         = "solarisBadRoute"
 	solarisNoRoute          = "solarisNoRoute"
 	solaris                 = "solaris"
+	solarisNoInterface      = "solarisNoInterface"
 	windowsBadRoute1        = "windowsBadRoute1"
 	windowsBadRoute2        = "windowsBadRoute2"
 	windowsLocalized        = "windowsLocalized"
@@ -224,6 +225,22 @@ Routing Table: IPv6
 ::1                         ::1                         UH      3   75382 lo0
 2001:470:deeb:32::/64       2001:470:deeb:32::17        U       3    2744 net0
 fe80::/10                   fe80::6082:52ff:fedc:7df0   U       3    8430 net0
+`),
+
+	solarisNoInterface: []byte(`
+Routing Table: IPv4
+  Destination            Gateway          Flags  Ref     Use     Interface
+-------------------- -------------------- ----- ----- ---------- ---------
+default              172.16.32.1          UG       49  681748414
+127.0.0.1            127.0.0.1            UH        2      52832 lo0
+172.16.32.0          172.16.32.17         U         5    1450483 net0
+
+Routing Table: IPv6
+  Destination/Mask            Gateway                   Flags Ref   Use    If
+--------------------------- --------------------------- ----- --- ------- -----
+::1                         ::1                         UH      2     966 lo0
+fe80::/10                   fe80::aabb:ccdd:1234:2      U       5   77620 net0
+default                     fe80::aabb:ccdd:1234:1      UG      3 4092447           
 `),
 
 	windowsBadRoute1: []byte(`


### PR DESCRIPTION
Interface name for default route may be omitted (i.e. if set in /etc/defaultrouter)

```
github.com/jackpal/gateway.parseNetstatToRouteStruct({0xc001226000, 0x3e9, 0xc0008f2000?})
	github.com/jackpal/gateway@v1.0.13/gateway_parsers.go:394 +0x605
github.com/jackpal/gateway.parseUnixGatewayIP({0xc001226000?, 0x6c2e313234373532?, 0x6264?})
	github.com/jackpal/gateway@v1.0.13/gateway_parsers.go:355 +0x1c
github.com/jackpal/gateway.discoverGatewayOSSpecific()
	github.com/jackpal/gateway@v1.0.13/gateway_solaris.go:22 +0x2a
github.com/jackpal/gateway.DiscoverGateway(...)
	github.com/jackpal/gateway@v1.0.13/gateway.go:46
```

See: syncthing/syncthing#9453
