### PR TITLE
Return all gateways

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -43,6 +43,15 @@ func (e *ErrInvalidRouteFileFormat) Error() string {
 
 // DiscoverGateway is the OS independent function to get the default gateway
 func DiscoverGateway() (ip net.IP, err error) {
+	ips, err := DiscoverGateways()
+	if err != nil {
+		return nil, err
+	}
+	return ips[0], nil
+}
+
+// DiscoverGateways is the OS independent function to get all gateways
+func DiscoverGateways() (ips []net.IP, err error) {
 	return discoverGatewayOSSpecific()
 }
 

--- a/gateway_linux.go
+++ b/gateway_linux.go
@@ -30,7 +30,7 @@ func readRoutes() ([]byte, error) {
 	return bytes, nil
 }
 
-func discoverGatewayOSSpecific() (ip net.IP, err error) {
+func discoverGatewayOSSpecific() (ips []net.IP, err error) {
 	bytes, err := readRoutes()
 	if err != nil {
 		return nil, err

--- a/gateway_solaris.go
+++ b/gateway_solaris.go
@@ -13,7 +13,7 @@ func readNetstat() ([]byte, error) {
 	return routeCmd.CombinedOutput()
 }
 
-func discoverGatewayOSSpecific() (ip net.IP, err error) {
+func discoverGatewayOSSpecific() (ips []net.IP, err error) {
 	bytes, err := readNetstat()
 	if err != nil {
 		return nil, err

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -161,14 +161,15 @@ func TestParseUnix(t *testing.T) {
 	})
 }
 
-func testGatewayAddress(t *testing.T, testcases []ipTestCase, fn func([]byte) (net.IP, error)) {
+func testGatewayAddress(t *testing.T, testcases []ipTestCase, fn func([]byte) ([]net.IP, error)) {
 	for i, tc := range testcases {
 		t.Run(tc.tableName, func(t *testing.T) {
-			net, err := fn(routeTables[tc.tableName])
+			nets, err := fn(routeTables[tc.tableName])
 			if tc.ok {
 				if err != nil {
 					t.Errorf("Unexpected error in test #%d: %v", i, err)
 				}
+				net := nets[0]
 				if net.String() != tc.ifaceIP {
 					t.Errorf("Unexpected gateway address %v != %s", net, tc.ifaceIP)
 				}

--- a/gateway_unimplemented.go
+++ b/gateway_unimplemented.go
@@ -7,8 +7,8 @@ import (
 	"net"
 )
 
-func discoverGatewayOSSpecific() (ip net.IP, err error) {
-	return ip, &ErrNotImplemented{}
+func discoverGatewayOSSpecific() (ips []net.IP, err error) {
+	return nil, &ErrNotImplemented{}
 }
 
 func discoverGatewayInterfaceOSSpecific() (ip net.IP, err error) {

--- a/gateway_windows.go
+++ b/gateway_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package gateway
@@ -8,7 +9,7 @@ import (
 	"syscall"
 )
 
-func discoverGatewayOSSpecific() (ip net.IP, err error) {
+func discoverGatewayOSSpecific() (ips []net.IP, err error) {
 	routeCmd := exec.Command("route", "print", "0.0.0.0")
 	routeCmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	output, err := routeCmd.CombinedOutput()
@@ -27,5 +28,9 @@ func discoverGatewayInterfaceOSSpecific() (ip net.IP, err error) {
 		return nil, err
 	}
 
-	return parseWindowsInterfaceIP(output)
+	ips, err := parseWindowsInterfaceIP(output)
+	if err != nil {
+		return nil, err
+	}
+	return ips[0], nil
 }


### PR DESCRIPTION
We had a use case where we needed to return _all_ gateways, not just the first.

This introduces a new function `DiscoverGateways` that will list all gateways, and the existing function `DiscoverGateway` has been refactored to use `DiscoverGateways` under the hood.